### PR TITLE
Tapestries scientific tif

### DIFF
--- a/view/__init__.py
+++ b/view/__init__.py
@@ -1,4 +1,4 @@
 from view.python_core.tapestries import create_tapestry
 from view.python_core.view_object import VIEW
 
-__all__ = ["create_tapestry", "VIEW"]
+__all__ = ["VIEW", "create_tapestry"]

--- a/view/gui/gdm_visualization.py
+++ b/view/gui/gdm_visualization.py
@@ -20,7 +20,6 @@ from view.python_core.overviews import (
 
 
 class MplCanvas(FigureCanvasQTAgg):
-
     def __init__(self, parent=None, width=5.0, height=4.0, dpi=100):
         fig = plt.Figure(
             figsize=(width, height), dpi=dpi, constrained_layout=True
@@ -30,7 +29,6 @@ class MplCanvas(FigureCanvasQTAgg):
 
 
 class GDMViz(QMainWindow):
-
     def __init__(self, p1, flags):
 
         super().__init__()
@@ -57,11 +55,15 @@ class GDMViz(QMainWindow):
             )
         )
 
+        overview_data = colorize_overview_add_border_etc(
+            overview_frame=p1.foto1, flags=flags_copy, p1=None
+        )
+
+        overview_generator_used = overview_data.overview_generator
+
         # data is in X, Y, color format
-        self.overview_frame_clean, data_limits, overview_generator_used = (
-            colorize_overview_add_border_etc(
-                overview_frame=p1.foto1, flags=flags_copy, p1=None
-            )
+        self.overview_frame_clean = (
+            overview_data.overview_frame_colorized_with_frame
         )
 
         roi_mask_color_label_tuples = (
@@ -77,7 +79,6 @@ class GDMViz(QMainWindow):
                 x.shape[0] < self.overview_frame_clean.shape[0]
                 or x.shape[1] < self.overview_frame_clean.shape[1]
             ):
-
                 enlarged_mask = np.zeros(
                     self.overview_frame_clean.shape[:2], dtype=bool
                 )
@@ -174,7 +175,6 @@ class GDMViz(QMainWindow):
             if x.currentText() != "---Choose a ROI to visualize---"
         ]
         for chosen_label in chosen_labels:
-
             chosen_mask, chosen_roi_color = self.roi_mask_dict[chosen_label]
 
             trace = self.roi_label_trace_dict[chosen_label]

--- a/view/python_core/areas.py
+++ b/view/python_core/areas.py
@@ -1,6 +1,6 @@
 import numpy as np
-from scipy.io.idl import readsav
-from scipy.ndimage.morphology import binary_erosion
+from scipy.io import readsav
+from scipy.ndimage import binary_erosion
 
 from view.python_core.io import read_tif_2Dor3D
 

--- a/view/python_core/io.py
+++ b/view/python_core/io.py
@@ -196,9 +196,9 @@ class MultiTiffReaderInga:
         tif_files.sort()  #
         tif_num = len(tif_files)
         # check the numbers. There mus be
-        assert (
-            measu_num * int(self.meta_dict["Duration"]) == tif_num
-        ), "io.py: Number of .tif file does not match info in .txt file"
+        assert measu_num * int(self.meta_dict["Duration"]) == tif_num, (
+            "io.py: Number of .tif file does not match info in .txt file"
+        )
 
         # now create the table with info about each measurement
         all_metadata_df = pd.DataFrame()
@@ -259,9 +259,9 @@ class MultiTiffReaderInga:
                 # I want the path above the main data folder '01_DATA'
                 path_parts = tif_file.parts
                 # check that '01_DATA' is part of the path
-                assert (
-                    "01_DATA" in path_parts
-                ), "path to data does not contain folder '01_DATA'"
+                assert "01_DATA" in path_parts, (
+                    "path to data does not contain folder '01_DATA'"
+                )
                 path_parts = path_parts[path_parts.index("01_DATA") + 1 : -1]
                 single_metadata["DBB_Folder"] = str(pl.Path(*path_parts))
                 # now for DBB1, list all single TIF files.
@@ -549,7 +549,7 @@ def write_tif_2Dor3D(
     else:
         if issubclass(dtype, np.integer):
             info = np.iinfo(dtype)
-        elif issubclass(dtype, np.flexible):
+        elif issubclass(dtype, np.floating):
             info = np.finfo(dtype)
         else:
             raise ValueError(
@@ -585,9 +585,9 @@ def write_tif_2Dor3D(
     if len(array_cast.shape) == 2:
         array_to_write = array_cast.swapaxes(0, 1)  # from XY to YX
         if labels is not None:
-            assert (
-                len(labels) == 1
-            ), f"Expected one label to write along with a one page TIF. Got ({len(labels)})"
+            assert len(labels) == 1, (
+                f"Expected one label to write along with a one page TIF. Got ({len(labels)})"
+            )
     elif len(array_cast.shape) == 3:
         array_to_write = array_cast.swapaxes(0, 2)  # from XYT to TYX
         if labels is not None:
@@ -660,9 +660,9 @@ def load_pst(filename):
         if not filepath.is_file():
             filepath = filepath.with_suffix(".ps")
 
-    assert (
-        filepath.is_file()
-    ), f"Could not find either of the following raw data files:\n{filename}.pst\n{filename}.ps"
+    assert filepath.is_file(), (
+        f"Could not find either of the following raw data files:\n{filename}.pst\n{filename}.ps"
+    )
 
     meta = {}
     with open(filepath.with_suffix(".inf")) as fh:
@@ -678,9 +678,9 @@ def load_pst(filename):
 
     expected_units = np.prod(shape)
 
-    assert (
-        filepath.stat().st_size >= 2 * expected_units
-    ), f"Expected at least {2 * expected_units} bytes in {filepath}. Found {filepath.stat().st_size}"
+    assert filepath.stat().st_size >= 2 * expected_units, (
+        f"Expected at least {2 * expected_units} bytes in {filepath}. Found {filepath.stat().st_size}"
+    )
 
     raw = np.fromfile(filepath, dtype="int16", count=expected_units)
     data = np.reshape(raw, shape, order="F")

--- a/view/python_core/movies/data_limit.py
+++ b/view/python_core/movies/data_limit.py
@@ -5,7 +5,6 @@ from view.python_core.misc import class_mixer
 
 
 class CalculatorDefault:
-
     def __init__(self):
 
         super().__init__()
@@ -17,12 +16,16 @@ class CalculatorDefault:
     def get_min(self, data):
 
         subsetted_data = self.subsetter(data)
-        return self.min(subsetted_data)
+        return float(self.min(subsetted_data))
+        # in case subsetter returns a masked array, self.min(subsettted_data) could be a MaskedConstant
+        # converting to float
 
     def get_max(self, data):
 
         subsetted_data = self.subsetter(data)
-        return self.max(subsetted_data)
+        return float(self.max(subsetted_data))
+        # in case subsetter returns a masked array, self.min(subsettted_data) could be a MaskedConstant
+        # converting to float
 
     def min(self, data):
 
@@ -38,7 +41,6 @@ class CalculatorDefault:
 
 
 class CalculatorFixedMin(CalculatorDefault):
-
     def __init__(self, SO_MV_scalemin, **kwargs):
 
         super().__init__(**kwargs)
@@ -50,7 +52,6 @@ class CalculatorFixedMin(CalculatorDefault):
 
 
 class CalculatorFixedMax(CalculatorDefault):
-
     def __init__(self, SO_MV_scalemax, **kwargs):
 
         super().__init__(**kwargs)
@@ -62,7 +63,6 @@ class CalculatorFixedMax(CalculatorDefault):
 
 
 class CalculatorNormalMax(CalculatorDefault):
-
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
@@ -72,7 +72,6 @@ class CalculatorNormalMax(CalculatorDefault):
 
 
 class CalculatorNormalMin(CalculatorDefault):
-
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
@@ -81,7 +80,6 @@ class CalculatorNormalMin(CalculatorDefault):
 
 
 class CalculatorPercentileMax(CalculatorDefault):
-
     def __init__(self, percentile_value_from_top, **kwargs):
         super().__init__(**kwargs)
         self.percentile_value = percentile_value_from_top
@@ -94,7 +92,6 @@ class CalculatorPercentileMax(CalculatorDefault):
 
 
 class CalculatorPercentileMin(CalculatorDefault):
-
     def __init__(self, percentile_value_from_bottom, **kwargs):
         super().__init__(**kwargs)
         self.percentile_value = percentile_value_from_bottom
@@ -105,7 +102,6 @@ class CalculatorPercentileMin(CalculatorDefault):
 
 
 class SquareSubsetter2D(CalculatorDefault):
-
     def __init__(self, fractional_margin, **kwargs):
 
         super().__init__(**kwargs)
@@ -122,7 +118,6 @@ class SquareSubsetter2D(CalculatorDefault):
 
 
 class SquareSubsetter3D(CalculatorDefault):
-
     def __init__(self, fractional_margin, **kwargs):
 
         super().__init__(**kwargs)
@@ -140,7 +135,6 @@ class SquareSubsetter3D(CalculatorDefault):
 
 
 class AreaSubsetter2D(CalculatorDefault):
-
     def __init__(self, frame_mask, **kwargs):
 
         super().__init__(**kwargs)
@@ -152,7 +146,6 @@ class AreaSubsetter2D(CalculatorDefault):
 
 
 class AreaSubsetter3D(CalculatorDefault):
-
     def __init__(self, frame_mask, **kwargs):
 
         super().__init__(**kwargs)
@@ -179,7 +172,6 @@ def get_data_limit_decider_3D(flags: FlagsManager, frame_mask):
         min_kwargs, max_kwargs = [{}, {}]
 
     if min_max_decider in [0, 1]:
-
         mixed_class = class_mixer(CalculatorFixedMin, CalculatorFixedMax)
         return mixed_class(
             SO_MV_scalemin=flags["SO_MV_scalemin"],
@@ -187,12 +179,10 @@ def get_data_limit_decider_3D(flags: FlagsManager, frame_mask):
         )
 
     elif min_max_decider == 2:
-
         mixed_class = class_mixer(min_class, max_class)
         return mixed_class(**min_kwargs, **max_kwargs)
 
     elif min_max_decider == 3:
-
         mixed_class = class_mixer(SquareSubsetter3D, min_class, max_class)
         return mixed_class(
             fractional_margin=flags["mv_indiScale3factor"],
@@ -201,19 +191,16 @@ def get_data_limit_decider_3D(flags: FlagsManager, frame_mask):
         )
 
     elif min_max_decider == 4:
-
         mixed_class = class_mixer(CalculatorFixedMin, max_class)
         return mixed_class(
             SO_MV_scalemin=flags["SO_MV_scalemin"], **max_kwargs
         )
 
     elif min_max_decider == 5:
-
         mixed_class = class_mixer(AreaSubsetter3D, min_class, max_class)
         return mixed_class(frame_mask=frame_mask, **min_kwargs, **max_kwargs)
 
     elif min_max_decider == 6:
-
         mixed_class = class_mixer(
             AreaSubsetter3D, CalculatorFixedMin, max_class
         )
@@ -242,7 +229,6 @@ def get_data_limit_decider_2D(flags: FlagsManager, frame_mask):
         min_kwargs, max_kwargs = [{}, {}]
 
     if min_max_decider in [0, 1]:
-
         mixed_class = class_mixer(CalculatorFixedMin, CalculatorFixedMax)
         return mixed_class(
             SO_MV_scalemin=flags["SO_MV_scalemin"],
@@ -250,12 +236,10 @@ def get_data_limit_decider_2D(flags: FlagsManager, frame_mask):
         )
 
     elif min_max_decider == 2:
-
         mixed_class = class_mixer(min_class, max_class)
         return mixed_class(**min_kwargs, **max_kwargs)
 
     elif min_max_decider == 3:
-
         mixed_class = class_mixer(SquareSubsetter2D, min_class, max_class)
         return mixed_class(
             fractional_margin=flags["SO_indiScale3factor"],
@@ -264,19 +248,16 @@ def get_data_limit_decider_2D(flags: FlagsManager, frame_mask):
         )
 
     elif min_max_decider == 4:
-
         mixed_class = class_mixer(CalculatorFixedMin, max_class)
         return mixed_class(
             SO_MV_scalemin=flags["SO_MV_scalemin"], **max_kwargs
         )
 
     elif min_max_decider == 5:
-
         mixed_class = class_mixer(AreaSubsetter2D, min_class, max_class)
         return mixed_class(frame_mask=frame_mask, **min_kwargs, **max_kwargs)
 
     elif min_max_decider == 6:
-
         mixed_class = class_mixer(
             AreaSubsetter2D, CalculatorFixedMin, max_class
         )

--- a/view/python_core/overviews/__init__.py
+++ b/view/python_core/overviews/__init__.py
@@ -163,9 +163,7 @@ def generate_overview_frame(flags, p1, feature_number=None):
     else:
         assert type(feature_number) is list and all(
             type(x) is int for x in feature_number
-        ), (
-            f"feature_number can be either None, 'all' or a list of ints. Got {feature_number}"
-        )
+        ), f"feature_number can be either None, 'all' or a list of ints. Got {feature_number}"
 
     try:
         return overview_frames[feature_number, :, :]
@@ -345,20 +343,18 @@ def pop_show_overview(
     else:
         assert type(stimulus_number) is list and all(
             type(x) is int for x in stimulus_number
-        ), (
-            f"stimulus_number can be either None, 'all' or a list of ints. Got {stimulus_number}"
-        )
+        ), f"stimulus_number can be either None, 'all' or a list of ints. Got {stimulus_number}"
 
     n_stim_used = len(stimulus_number)
     overview_frames_columns = []
     for stim_ind in stimulus_number:
-        assert type(stim_ind) is int, (
-            f"For flag 'CTV_StimulusNumber' Expected int, got {type(stim_ind)}({stim_ind})"
-        )
+        assert (
+            type(stim_ind) is int
+        ), f"For flag 'CTV_StimulusNumber' Expected int, got {type(stim_ind)}({stim_ind})"
         if n_stim > 0:
-            assert 0 <= stim_ind < n_stim, (
-                f"IndexError: Current measurement has {n_stim} stimuli, therefore stimulus_number can be in [0, {n_stim - 1}]. Got {stim_ind}"
-            )
+            assert (
+                0 <= stim_ind < n_stim
+            ), f"IndexError: Current measurement has {n_stim} stimuli, therefore stimulus_number can be in [0, {n_stim - 1}]. Got {stim_ind}"
 
         flags_copy = flags.copy()
         flags_copy.update_flags({"CTV_StimulusNumber": stim_ind})
@@ -443,7 +439,9 @@ def pop_show_overview(
                     _roi_mask,
                     color,
                     label,
-                ) in overview_data.overview_generator.roi_marker.roi_mask_color_label_tuples:
+                ) in (
+                    overview_data.overview_generator.roi_marker.roi_mask_color_label_tuples
+                ):
                     ax.plot([-1], [-1], "-", color=color, label=label)
                 ax.legend(
                     bbox_to_anchor=(1.05, 1),

--- a/view/python_core/overviews/__init__.py
+++ b/view/python_core/overviews/__init__.py
@@ -20,6 +20,11 @@ from view.python_core.movies.static_border import (
     get_static_border_adder_2D,
 )
 from view.python_core.overviews.ctv_handlers import get_ctv_handler
+from view.python_core.overviews.data_classes import (
+    OverviewData,
+    OverviewDataForOutput,
+    prep_overview_for_output,
+)
 from view.python_core.overviews.roi_marker import get_roi_marker_2D
 from view.python_core.p1_class import Default_P1_Getter
 from view.python_core.utils.colors import interpret_flag_SO_MV_colortable
@@ -158,7 +163,9 @@ def generate_overview_frame(flags, p1, feature_number=None):
     else:
         assert type(feature_number) is list and all(
             type(x) is int for x in feature_number
-        ), f"feature_number can be either None, 'all' or a list of ints. Got {feature_number}"
+        ), (
+            f"feature_number can be either None, 'all' or a list of ints. Got {feature_number}"
+        )
 
     try:
         return overview_frames[feature_number, :, :]
@@ -186,7 +193,9 @@ def generate_overview_image(flags, p1):
     )
 
 
-def colorize_overview_add_border_etc(overview_frame, flags, p1=None):
+def colorize_overview_add_border_etc(
+    overview_frame, flags, p1=None
+) -> OverviewData:
     """
     Colorizes <overview_frame>, applies borders and border annotations according to <flags>. If <overview_frame> was
     generated from a p1 object, pass it to <p1>, else let it default to None. A p1 object is only required when <flags>
@@ -262,14 +271,16 @@ def colorize_overview_add_border_etc(overview_frame, flags, p1=None):
         },
     )
 
-    return (
-        overview_frame_final,
-        data_to_01_mapper.get_data_limits(),
-        overview_generator,
+    return OverviewData(
+        overview_frame=overview_frame,
+        overview_frame_preprocessed=overview_frame_preprocessed,
+        overview_frame_colorized_with_frame=overview_frame_final,
+        data_limits=data_to_01_mapper.get_data_limits(),
+        overview_generator=overview_generator,
     )
 
 
-def generate_overview_image_for_output(flags, p1):
+def generate_overview_image_for_output(flags, p1) -> OverviewDataForOutput:
     """
     Generates overview frame and transforms it so that it can be readily used either for plt.imshow or for
     saving with tifffile.imsave
@@ -281,32 +292,10 @@ def generate_overview_image_for_output(flags, p1):
     """
 
     # data is in X, Y, color format
-    overview_frame, data_limits, overview_generator_used = (
-        generate_overview_image(flags, p1)
-    )
+    overview_data = generate_overview_image(flags, p1)
 
     # conversion to YX format, uint8 and flip Y
-    return prep_overview_for_output(overview=overview_frame), data_limits
-
-
-def prep_overview_for_output(overview):
-    """
-    Prepare overview image for output as TIFs or as a frame of a movie
-    :param numpy.ndarray overview: float64 X,Y,Color format with origin at bottom left
-    :rtype: numpy.ndarray
-    :returns: uint8; Y,X, Color format with origin at top left
-    """
-
-    # need to swap axes as tiff expects YX
-    frame_data_numpy_swapped = overview.swapaxes(0, 1)
-
-    # need to convert it to 8 bit from float
-    frame_data_numpy_swapped_uint8 = np.array(
-        frame_data_numpy_swapped * 255, dtype=np.uint8
-    )
-
-    # flip Y since origin in tiff is top left
-    return np.flip(frame_data_numpy_swapped_uint8, axis=0)
+    return prep_overview_for_output(overview_data)
 
 
 def get_current_pyplot_window_titles():
@@ -356,18 +345,20 @@ def pop_show_overview(
     else:
         assert type(stimulus_number) is list and all(
             type(x) is int for x in stimulus_number
-        ), f"stimulus_number can be either None, 'all' or a list of ints. Got {stimulus_number}"
+        ), (
+            f"stimulus_number can be either None, 'all' or a list of ints. Got {stimulus_number}"
+        )
 
     n_stim_used = len(stimulus_number)
     overview_frames_columns = []
     for stim_ind in stimulus_number:
-        assert (
-            type(stim_ind) is int
-        ), f"For flag 'CTV_StimulusNumber' Expected int, got {type(stim_ind)}({stim_ind})"
+        assert type(stim_ind) is int, (
+            f"For flag 'CTV_StimulusNumber' Expected int, got {type(stim_ind)}({stim_ind})"
+        )
         if n_stim > 0:
-            assert (
-                0 <= stim_ind < n_stim
-            ), f"IndexError: Current measurement has {n_stim} stimuli, therefore stimulus_number can be in [0, {n_stim - 1}]. Got {stim_ind}"
+            assert 0 <= stim_ind < n_stim, (
+                f"IndexError: Current measurement has {n_stim} stimuli, therefore stimulus_number can be in [0, {n_stim - 1}]. Got {stim_ind}"
+            )
 
         flags_copy = flags.copy()
         flags_copy.update_flags({"CTV_StimulusNumber": stim_ind})
@@ -399,20 +390,18 @@ def pop_show_overview(
         ):
             row_ind = feature_ind
             ax = axs[row_ind, col_ind]
-            (
-                overview_frame_colorized_with_frame,
-                data_limits,
-                overview_generator_used,
-            ) = colorize_overview_add_border_etc(
+            overview_data = colorize_overview_add_border_etc(
                 overview_frame=overview_frame_this_feature, flags=flags, p1=p1
             )
 
-            overview_for_output = prep_overview_for_output(
-                overview_frame_colorized_with_frame
-            )
+            overview_for_output = prep_overview_for_output(overview_data)
 
-            ax.imshow(np.flip(overview_for_output, axis=0), origin="lower")
+            ax.imshow(
+                np.flip(overview_for_output.overview_frame_for_output, axis=0),
+                origin="lower",
+            )
             legendfactor = flags["SO_scaleLegendFactor"]
+            data_limits = overview_data.data_limits
             ax.set_title(
                 f"Feature Number: {feature_ind:d}; Stimulus Number: {stim_ind:d}\nFalse color scale (CTV*{legendfactor:2.1f}) is {data_limits[0] * legendfactor:2.3f} to {data_limits[1] * legendfactor:2.3f}"
             )
@@ -454,9 +443,7 @@ def pop_show_overview(
                     _roi_mask,
                     color,
                     label,
-                ) in (
-                    overview_generator_used.roi_marker.roi_mask_color_label_tuples
-                ):
+                ) in overview_data.overview_generator.roi_marker.roi_mask_color_label_tuples:
                     ax.plot([-1], [-1], "-", color=color, label=label)
                 ax.legend(
                     bbox_to_anchor=(1.05, 1),
@@ -484,11 +471,12 @@ def create_bw_image_from_frame(frame, extra_flags=None):
     flags = FlagsManager()
     flags.update_flags(flags_2_update)
 
-    if type(extra_flags) is dict:
-        flags.update_flags(extra_flags)
+    assert type(extra_flags) is dict, ValueError
 
-    frame_bw, data_limits, overview_generator_used = (
-        colorize_overview_add_border_etc(overview_frame=frame, flags=flags)
+    flags.update_flags(extra_flags)
+
+    overview_data = colorize_overview_add_border_etc(
+        overview_frame=frame, flags=flags
     )
 
-    return frame_bw
+    return overview_data.overview_frame_colorized_with_frame

--- a/view/python_core/overviews/data_classes.py
+++ b/view/python_core/overviews/data_classes.py
@@ -67,7 +67,7 @@ def prep_np_array_for_output(np_array):
     """
     Prepare overview image for output as TIFs or as a frame of a movie
 
-    :param np_array: np.array
+    :param np_array: np.array values, float64, X, Y, Color format with origin at bottom left
     :return: uint8; Y,X, Color format with origin at top left
     :rtype: numpy.ndarray
     """

--- a/view/python_core/overviews/data_classes.py
+++ b/view/python_core/overviews/data_classes.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import typing
+from dataclasses import dataclass
+
+import numpy as np
+
+if typing.TYPE_CHECKING:
+    from view.python_core.overviews import OverviewColorizerAnnotator
+
+
+@dataclass
+class OverviewData:
+    """Container class for raw overview created from sig, processed version of it and related values"""
+
+    overview_frame: np.ndarray = None
+    overview_frame_preprocessed: np.ndarray = None
+    overview_frame_colorized_with_frame: np.ndarray = None
+    data_limits: tuple = None
+    overview_generator: OverviewColorizerAnnotator = None
+
+
+@dataclass
+class OverviewDataForOutput(OverviewData):
+    """
+    Extends OverviewData to add `overview_frame_for_output`
+    """
+
+    overview_frame_for_output: np.ndarray = None
+
+    @classmethod
+    def init_from_overview_data(cls, overview_data):
+
+        return OverviewDataForOutput(
+            overview_frame=overview_data.overview_frame,
+            overview_frame_preprocessed=overview_data.overview_frame_preprocessed,
+            overview_frame_colorized_with_frame=overview_data.overview_frame_colorized_with_frame,
+            data_limits=overview_data.data_limits,
+            overview_generator=overview_data.overview_generator,
+        )
+
+
+def prep_overview_for_output(
+    overview_data: OverviewData,
+) -> OverviewDataForOutput:
+    """
+    Prepare overview image for output as TIFs or as a frame of a movie and writes into self.overview_frame_for_output
+    uses overview_frame_colorized_with_frame numpy.ndarray overview: float64 X,Y,Color format with origin at bottom left
+    :rtype: numpy.ndarray
+    :returns: uint8; Y,X, Color format with origin at top left
+    """
+
+    overview_data_for_output = OverviewDataForOutput.init_from_overview_data(
+        overview_data=overview_data
+    )
+
+    overview_data_for_output.overview_frame_for_output = (
+        prep_np_array_for_output(
+            overview_data_for_output.overview_frame_colorized_with_frame
+        )
+    )
+
+    return overview_data_for_output
+
+
+def prep_np_array_for_output(np_array):
+    """
+    Prepare overview image for output as TIFs or as a frame of a movie
+
+    :param np_array: np.array
+    :return: uint8; Y,X, Color format with origin at top left
+    :rtype: numpy.ndarray
+    """
+
+    # need to swap axes as tiff expects YX
+    frame_data_numpy_swapped = np_array.swapaxes(0, 1)
+
+    # need to convert it to 8 bit from float
+    frame_data_numpy_swapped_uint8 = np.array(
+        frame_data_numpy_swapped * 255, dtype=np.uint8
+    )
+
+    # flip Y since origin in tiff is top left
+    return np.flip(frame_data_numpy_swapped_uint8, axis=0)

--- a/view/python_core/p1_class/filters.py
+++ b/view/python_core/p1_class/filters.py
@@ -1,5 +1,5 @@
 import numpy as np
-from scipy.ndimage.filters import median_filter, uniform_filter
+from scipy.ndimage import median_filter, uniform_filter
 from scipy.signal import firwin, kaiserord, lfilter
 
 

--- a/view/python_core/stimuli/__init__.py
+++ b/view/python_core/stimuli/__init__.py
@@ -14,7 +14,7 @@ class BaseStimuliiHandler:
                 "Pulse Start Time",
                 "Pulse End Time",
                 "Sampling Period",
-            )
+            ),
         )
         self.stimulus_offset_td = pd.Timedelta(0)
 
@@ -82,9 +82,9 @@ class BaseStimuliiHandler:
             and pd.isnull(on_ms)
         ):
             # stimulus start, based on on_frame
-            assert (
-                on_frame >= 0
-            ), f"on_frame must be >= 0. {on_frame} specified"
+            assert on_frame >= 0, (
+                f"on_frame must be >= 0. {on_frame} specified"
+            )
             on_time_from_frame = on_frame * data_sampling_period_td
         elif pd.isnull(on_frame) and not pd.isnull(on_ms):
             # stimulus start, based on on_ms
@@ -132,9 +132,12 @@ class BaseStimuliiHandler:
             columns=self.stimulus_frame.columns,
         )
 
-        self.stimulus_frame = pd.concat(
-            [self.stimulus_frame, temp_df], ignore_index=True
-        )
+        if self.stimulus_frame.shape[0] == 0:
+            self.stimulus_frame = temp_df
+        else:
+            self.stimulus_frame = pd.concat(
+                [self.stimulus_frame, temp_df], ignore_index=True
+            )
 
         return 0
 
@@ -162,9 +165,9 @@ class BaseStimuliiHandler:
         concs: list of str, containing concentration information
         """
 
-        assert all(
-            isinstance(x, pd.Timedelta) for x in times
-        ), "times must be of type pandas.TimeDelta"
+        assert all(isinstance(x, pd.Timedelta) for x in times), (
+            "times must be of type pandas.TimeDelta"
+        )
 
         odors = []
         concs = []

--- a/view/python_core/tapestries/__init__.py
+++ b/view/python_core/tapestries/__init__.py
@@ -107,6 +107,16 @@ class TapestryCreater:
 
         return create_movies, flag_changes
 
+    def interpret_row_settings_for_scientific_tif(
+        self, row, current_save_scientific_tif
+    ) -> bool:
+
+        # interpret whether scientific tifs are to be saved
+        if "save_scientific_tif" in row:
+            return row["save_scientific_tif"]
+        else:
+            return current_save_scientific_tif
+
     def generate_overview_movies(
         self,
         measu: int,
@@ -165,6 +175,7 @@ class TapestryCreater:
         current_movie_flags = {}
         current_create_movies = False
         current_extra_formats = []
+        current_save_scientific_tif = False
 
         # initialize dummy values for the case if no patches get initialized
         aspect_ratio = 1
@@ -188,6 +199,12 @@ class TapestryCreater:
             current_create_movies, current_movie_flags = (
                 self.interpret_row_settings_for_movies(
                     row, current_create_movies, current_movie_flags
+                )
+            )
+
+            current_save_scientific_tif = (
+                self.interpret_row_settings_for_scientific_tif(
+                    row, current_save_scientific_tif
                 )
             )
 
@@ -227,6 +244,7 @@ class TapestryCreater:
                         extra_formats=current_extra_formats,
                         op_folder_path=self.current_tapestry_dir_path,
                         row_string=row_name,
+                        save_scientific_tif=current_save_scientific_tif,
                     )
 
                     overview_frame_for_output = (

--- a/view/python_core/tapestries/__init__.py
+++ b/view/python_core/tapestries/__init__.py
@@ -3,7 +3,11 @@ import pathlib as pl
 import jinja2 as j2
 
 from view.python_core.get_internal_files import get_internal_jinja_template
-from view.python_core.tapestries.patch import EmptyPatch, get_nonempty_patch
+from view.python_core.tapestries.patch import (
+    EmptyPatch,
+    Patch,
+    get_nonempty_patch,
+)
 from view.python_core.tapestries.tapestry_config import TapestryConfig
 from view.python_core.utils.colors import mpl_color_to_css
 from view.python_core.view_object import VIEW
@@ -126,8 +130,8 @@ class TapestryCreater:
             flags2update["SO_xgap"] = self.view.p1.metadata.format_x / 6
         self.view.update_flags(flags2update)
 
-        # generate overview, data limits and return them
-        overview, data_limits = (
+        # generate overview prepped for output
+        overview_data_for_output = (
             self.view.generate_overview_for_output_for_current_measurement()
         )
 
@@ -141,7 +145,10 @@ class TapestryCreater:
         else:
             op_file = None
 
-        return overview, data_limits, op_file
+        return (
+            overview_data_for_output,
+            op_file,
+        )
 
     def save_all_overviews_preparing_for_tapestry(self):
         """
@@ -158,6 +165,10 @@ class TapestryCreater:
         current_movie_flags = {}
         current_create_movies = False
         current_extra_formats = []
+
+        # initialize dummy values for the case if no patches get initialized
+        aspect_ratio = 1
+        colorbar2width = 0.3
 
         # iterate over measurements
         # row is guaranteed to contain one key called 'measus', which is ensured to be a non empty.
@@ -188,7 +199,7 @@ class TapestryCreater:
 
                 else:
                     # generate an overview and optionally a movie, updating flags before generation
-                    overview, data_limits, op_movie_file = (
+                    overview_data_for_output, op_movie_file = (
                         self.generate_overview_movies(
                             measu,
                             current_overview_flags,
@@ -203,13 +214,12 @@ class TapestryCreater:
                     )
 
                     patch = get_nonempty_patch(
-                        overview=overview,
-                        data_limits=data_limits,
+                        overview_data_for_output=overview_data_for_output,
                         measurement_row=measurement_row,
                         animal=current_animal,
                         measu=measu,
                         flag_changes=current_overview_flags,
-                        op_movie_file=op_movie_file,
+                        movie_file_to_move=op_movie_file,
                     )
 
                     patch.initialize_texts(self.tapestry_config)
@@ -219,24 +229,26 @@ class TapestryCreater:
                         row_string=row_name,
                     )
 
+                    overview_frame_for_output = (
+                        overview_data_for_output.overview_frame_for_output
+                    )
                     # save aspect ratio as it is needed later for arranging overviews
                     # overview_for_output has format YX
-                    aspect_ratio = overview.shape[1] / overview.shape[0]
+                    aspect_ratio = (
+                        overview_frame_for_output.shape[1]
+                        / overview_frame_for_output.shape[0]
+                    )
 
                     # ratio: (padding for colorbar / overview width)
                     # overview_for_output has format YX
                     colorbar2width = 1 - (
-                        self.view.p1.metadata.format_x / overview.shape[1]
+                        self.view.p1.metadata.format_x
+                        / overview_frame_for_output.shape[1]
                     )
 
                 patches_row.append(patch)
 
             patches_collection.append(patches_row)
-
-        # initialize dummy values if no patches were initialized
-        if len(patches_collection) == 0:
-            aspect_ratio = 1
-            colorbar2width = 0.3
 
         # convert bg and fg colors to css
         bg_color_css = mpl_color_to_css(self.view.flags["SO_bgColor"])
@@ -270,10 +282,15 @@ class TapestryCreater:
         all_lower_limits = []
 
         for row in patches_collection:
-            for patch in row:
-                if hasattr(patch, "data_limits"):
-                    all_upper_limits.append(patch.data_limits[1])
-                    all_lower_limits.append(patch.data_limits[0])
+            for patch_ in row:
+                # patch is an internally used name in python
+                if isinstance(patch_, Patch):
+                    all_upper_limits.append(
+                        patch_.overview_data_for_output.data_limits[1]
+                    )
+                    all_lower_limits.append(
+                        patch_.overview_data_for_output.data_limits[0]
+                    )
 
         all_data_limits = [
             round(min(all_lower_limits), 3),

--- a/view/python_core/tapestries/patch.py
+++ b/view/python_core/tapestries/patch.py
@@ -5,8 +5,11 @@ import pprint
 import typing
 from dataclasses import dataclass
 
+import numpy as np
 import pandas as pd
 from PIL import Image
+
+from view.python_core.io import write_tif_2Dor3D
 
 if typing.TYPE_CHECKING:
     from view.python_core.overviews import OverviewDataForOutput
@@ -78,6 +81,7 @@ class Patch(EmptyPatch):
         extra_formats: typing.Iterable[str],
         op_folder_path: pl.Path,
         row_string: str,
+        save_scientific_tif: bool = False,
     ):
 
         assert self.text_below != "uninitialized", (
@@ -101,6 +105,17 @@ class Patch(EmptyPatch):
             measu_op_file = f"{image_op_stem}.{output_extension}"
             self.pil_image.save(measu_op_file)
 
+        if save_scientific_tif:
+            scientific_tif_filename = f"{image_op_stem}.sci.tif"
+            scientific_tif_array_float32 = self.overview_data_for_output.overview_frame_preprocessed.astype(
+                np.float32
+            )
+            # specifically type casting here instead of using the argument "dtype" of "write_tif_2Dor3D", as the function tries to ensure safe type casting, which is not the case from float64 to float32. However, np.astype rounds values and avoids overflow and underflow problems, so we can use.
+            write_tif_2Dor3D(
+                array_xy_or_xyt=scientific_tif_array_float32,
+                tif_file=scientific_tif_filename,
+            )
+
         return image_op_stem
 
 
@@ -117,10 +132,11 @@ class PatchWithMovie(Patch):
         extra_formats: typing.Iterable[str],
         op_folder_path: pl.Path,
         row_string: str,
+        save_scientific_tif: bool = False,
     ):
 
         image_op_stem = super().write_overview_movie_files(
-            extra_formats, op_folder_path, row_string
+            extra_formats, op_folder_path, row_string, save_scientific_tif
         )
 
         # move movie next to the created overview files

--- a/view/python_core/tapestries/patch.py
+++ b/view/python_core/tapestries/patch.py
@@ -1,12 +1,16 @@
+from __future__ import annotations
+
 import pathlib as pl
 import pprint
 import typing
+from dataclasses import dataclass
 
-import numpy as np
 import pandas as pd
 from PIL import Image
 
-from view.python_core.tapestries.tapestry_config import TapestryConfig
+if typing.TYPE_CHECKING:
+    from view.python_core.overviews import OverviewDataForOutput
+    from view.python_core.tapestries.tapestry_config import TapestryConfig
 
 
 def sanitize_formats(formats: typing.Iterable[str]) -> typing.Iterable[str]:
@@ -18,51 +22,42 @@ def sanitize_formats(formats: typing.Iterable[str]) -> typing.Iterable[str]:
     return formats
 
 
+@dataclass
 class EmptyPatch:
-    def __init__(self):
-
-        super().__init__()
-        self.image_relative_path = "Excluded"
-        self.text_below = ""
-        self.text_right_bottom = ""
-        self.text_right_top = ""
-        self.animal = "Invalid"
-        self.flag_changes = "Invalid"
-        self.movie_file = None
+    image_relative_path: str = "Excluded"
+    text_below: str = ""
+    text_right_bottom: str = ""
+    text_right_top: str = ""
+    animal: str = "Invalid"
+    flag_changes: str = "Invalid"
+    movie_file_for_html: str = None
 
 
+@dataclass
 class Patch(EmptyPatch):
-    def __init__(
-        self,
-        overview: np.ndarray,
-        data_limits: typing.Iterable[float],
-        measurement_row: pd.Series,
-        animal: str,
-        measu: int,
-        flag_changes: dict,
-    ):
+    overview_data_for_output: OverviewDataForOutput = None
+    measurement_row: pd.Series = None
+    measu: int = None
+    pil_image: Image = None
+    image_relative_path: pl.Path | str = None
 
-        super().__init__()
-        self.overview = overview
+    def __post_init__(self):
 
-        self.pil_image = Image.fromarray(overview)
-        self.data_limits = data_limits
+        self.pil_image = Image.fromarray(
+            self.overview_data_for_output.overview_frame_for_output
+        )
 
         self.text_right_bottom, self.text_right_top = [
-            f"{x:.3g}" for x in data_limits
+            f"{x:.3g}" for x in self.overview_data_for_output.data_limits
         ]
-
-        self.measurement_row = measurement_row
 
         self.text_below = "uninitialized"
 
         self.image_relative_path = "uninitialized"
 
-        self.animal = animal
-
-        self.measu = measu
-
-        self.flag_changes = pprint.pformat(flag_changes).replace("\n", "<br>")
+        self.flag_changes = pprint.pformat(self.flag_changes).replace(
+            "\n", "<br>"
+        )
 
     def initialize_texts(self, tapestry_config: TapestryConfig):
 
@@ -109,22 +104,13 @@ class Patch(EmptyPatch):
         return image_op_stem
 
 
+@dataclass
 class PatchWithMovie(Patch):
-    def __init__(
-        self,
-        overview: np.ndarray,
-        data_limits: typing.Iterable[float],
-        measurement_row: pd.Series,
-        animal: str,
-        measu: int,
-        flag_changes: dict,
-        op_movie_file: str,
-    ):
+    movie_file_to_move: str = None
 
-        super().__init__(
-            overview, data_limits, measurement_row, animal, measu, flag_changes
-        )
-        self.movie_file = op_movie_file
+    def __post_init__(self):
+
+        super().__post_init__()
 
     def write_overview_movie_files(
         self,
@@ -138,35 +124,33 @@ class PatchWithMovie(Patch):
         )
 
         # move movie next to the created overview files
-        temp_movie_path = pl.Path(self.movie_file)
+        temp_movie_path = pl.Path(self.movie_file_to_move)
         movie_op_file_path = f"{image_op_stem}_movie{temp_movie_path.suffix}"
         temp_movie_path.replace(movie_op_file_path)
 
-        self.movie_file = movie_op_file_path
+        self.movie_file_for_html = movie_op_file_path
 
 
 def get_nonempty_patch(
-    overview,
-    data_limits,
-    measurement_row,
-    animal,
-    measu,
-    flag_changes,
-    op_movie_file,
+    overview_data_for_output: OverviewDataForOutput,
+    measurement_row: pd.Series,
+    animal: str,
+    measu: int,
+    flag_changes: str,
+    movie_file_to_move: str,
 ):
 
-    if op_movie_file is None:
-        return Patch(
-            overview, data_limits, measurement_row, animal, measu, flag_changes
-        )
+    patch_input = {
+        "overview_data_for_output": overview_data_for_output,
+        "measurement_row": measurement_row,
+        "animal": animal,
+        "measu": measu,
+        "flag_changes": flag_changes,
+    }
+    if movie_file_to_move is None:
+        return Patch(**patch_input)
 
     else:
         return PatchWithMovie(
-            overview,
-            data_limits,
-            measurement_row,
-            animal,
-            measu,
-            flag_changes,
-            op_movie_file,
+            **patch_input, movie_file_to_move=movie_file_to_move
         )

--- a/view/python_core/tests/generate_overviews_test.py
+++ b/view/python_core/tests/generate_overviews_test.py
@@ -23,7 +23,8 @@ class OverviewsGenerator:
         self.view.update_flags(flags_to_update)
         self.view.load_measurement_data(self.test_animal, self.test_measu)
         self.view.calculate_signals()
-        frame_data2write, data_limits = (
+
+        overview_data_for_output = (
             self.view.generate_overview_for_output_for_current_measurement()
         )
 
@@ -41,7 +42,9 @@ class OverviewsGenerator:
         )
 
         tifffile.imwrite(
-            op_file_name, data=frame_data2write, photometric="rgb"
+            op_file_name,
+            data=overview_data_for_output.overview_frame_for_output,
+            photometric="rgb",
         )
 
 

--- a/view/python_core/tests/generate_tapestries_test.py
+++ b/view/python_core/tests/generate_tapestries_test.py
@@ -98,6 +98,7 @@ if __name__ == "__main__":
     # run_with_yml_name("different_animals")
     # run_with_yml_name("with_movies_stack_tif")
     # run_with_yml_name("with_movies_libx264")
-    run_with_yml_name("custom_csv_linux")
+    # run_with_yml_name("custom_csv_linux")
     # run_with_yml_name("custom_csv_windows")
     # run_with_yml_name("different_flags")
+    run_with_yml_name("save_scientific_tif")

--- a/view/python_core/tests/generate_tapestries_test.py
+++ b/view/python_core/tests/generate_tapestries_test.py
@@ -1,4 +1,5 @@
 import pathlib as pl
+import platform
 
 import pytest
 
@@ -25,16 +26,26 @@ def gen_non_default_configs():
         / "tapestry_configs"
     )
     for child in progs_path.iterdir():
-        if child.suffix == ".yml" and child.name != "default.yml":
-            # if child.name.lower().find("linux") >= 0 and platform.system() != "Linux":
-            #     continue
-            # elif child.name.lower().find("windows") >= 0 and platform.system() != "Windows":
-            #     continue
+        # platform_mismatch = (
+        #     child.name.lower().find("linux") >= 0
+        #     and platform.system() != "Linux"
+        # ) or (
+        #     child.name.lower().find("windows") >= 0
+        #     and platform.system() != "Windows"
+        # )
+        #
+        # if (
+        #     child.suffix == ".yml"
+        #     and child.name != "default.yml"
+        #     and platform_mismatch
+        # ):
+        #     continue
+        # TODO separate this generator into those that should pass irrespective of platform and those that should condidtionally pass/fail based on platform
 
-            # create_tapestry.description = f"Generating tapestry with {child.name}"
-            # TODO port descriptions for use with pytest
+        # create_tapestry.description = f"Generating tapestry with {child.name}"
+        # TODO port descriptions for use with pytest
 
-            yield str(child), test_yml, text_below
+        yield str(child), test_yml, text_below
 
 
 def test_default():
@@ -49,7 +60,8 @@ non_default_configs = list(gen_non_default_configs())
 
 
 @pytest.mark.parametrize(
-    "tapestry_yml_file, view_yml_file, text_below_func", non_default_configs
+    "tapestry_yml_file, view_yml_file, text_below_func",
+    non_default_configs,
 )
 def test_non_default_configs(
     tapestry_yml_file, view_yml_file, text_below_func
@@ -86,6 +98,6 @@ if __name__ == "__main__":
     # run_with_yml_name("different_animals")
     # run_with_yml_name("with_movies_stack_tif")
     # run_with_yml_name("with_movies_libx264")
-    # run_with_yml_name("custom_csv_linux")
-    run_with_yml_name("custom_csv_windows")
+    run_with_yml_name("custom_csv_linux")
+    # run_with_yml_name("custom_csv_windows")
     # run_with_yml_name("different_flags")

--- a/view/python_core/view_object.py
+++ b/view/python_core/view_object.py
@@ -18,6 +18,8 @@ from view.python_core.measurement_list import MeasurementList
 from view.python_core.measurement_list.importers import get_setup_extension
 from view.python_core.movies import export_movie
 from view.python_core.overviews import (
+    OverviewData,
+    OverviewDataForOutput,
     generate_overview_image,
     generate_overview_image_for_output,
 )
@@ -162,9 +164,9 @@ class VIEW:
             lst_fle=list_file, LE_loadExp=self.flags["LE_loadExp"]
         )
 
-        assert self.measurement_list.animal_name is not None, (
-            "Something went wrong!"
-        )
+        assert (
+            self.measurement_list.animal_name is not None
+        ), "Something went wrong!"
         self.flags.update_flags(
             {"STG_ReportTag": self.measurement_list.animal_name}
         )
@@ -390,7 +392,7 @@ class VIEW:
 
         return ctv_handler.apply(self.p1.sig1)
 
-    def generate_overview_for_current_measurement(self):
+    def generate_overview_for_current_measurement(self) -> OverviewData:
         """
         Generate an overview of the measurement data currently loaded based on current flags and returns it
         :return: overview_frame, data_limits, overview_generator_used
@@ -403,7 +405,9 @@ class VIEW:
             self.calculate_signals()
         return generate_overview_image(flags=self.flags, p1=self.p1)
 
-    def generate_overview_for_output_for_current_measurement(self):
+    def generate_overview_for_output_for_current_measurement(
+        self,
+    ) -> OverviewDataForOutput:
         """
         Generates overview frame and transforms it so that it can be readily used either for plt.imshow or for
         saving with tifffile.imsave


### PR DESCRIPTION
# Description:
This PR adds a new option to tapestries called "save_scientific_tif", which allows users to create scientific tiff files corresponding to overviews. A scientific tiff file contains raw values of the overview after filtering and cropping, but without colorization and without colorbar, stored as  a 2D Tiff encoded in float32 number format.

Documentation has been updated: https://github.com/galizia-lab/pyview/wiki/Tapestry-Configuration-file

# How to test
Insert this option into a tapestry config and create a tapestry ([related documentation](https://github.com/galizia-lab/pyview/wiki/Tapestry-Configuration-file)). I have tested locally on linux using "Fake Data" dataset and the following tapestry configuration file

```yaml
row1:
  animal: FakeData
  flags:
    SO_individualScale: 2
    SO_Method: 0
    CTV_Method: 22
    CTV_firstframe: 22
    CTV_lastframe: 35
    CTV_scalebar: True
  measus: [1, 2, 3]
  extra_formats: [tif]
row2:
  measus: [4, 5, 6]
  save_scientific_tif: True
row3:
  measus: [7, 8, 9]
```